### PR TITLE
add a connector for local model packs

### DIFF
--- a/src/java/org/jmad/modelpack/connect/ConnectorIds.java
+++ b/src/java/org/jmad/modelpack/connect/ConnectorIds.java
@@ -8,6 +8,7 @@ public final class ConnectorIds {
 
     public static final String GITLAB_GROUP_API_V4 = "gitlab-group-api-v4";
     public static final String INTERNAL_CONNECTOR_ID = "internal-classpath";
+    public static final String LOCAL_FILE_CONNECTOR_ID = "local-file";
 
     private ConnectorIds() {
         /* Only constants */

--- a/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
+++ b/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
@@ -20,7 +20,7 @@ public class LocalFileModelPackageConnector implements InternalModelPackageConne
     private static final String LOCAL_NAME_PREFIX = "LOCAL-";
 
     @Autowired
-    JMadService jMadService;
+    private JMadService jMadService;
 
     @Override
     public Flux<JMadModelDefinition> modelDefinitionsFor(ModelPackageVariant modelPackage) {

--- a/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
+++ b/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
@@ -17,7 +17,7 @@ import static java.util.Arrays.stream;
 public class LocalFileModelPackageConnector implements InternalModelPackageConnector {
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalFileModelPackageConnector.class);
     private static final Variant LOCAL_VARIANT = Variant.release("LOCAL", new Commit("LOCAL", "LOCAL"));
-    public static final String LOCAL_NAME_PREFIX = "LOCAL-";
+    private static final String LOCAL_NAME_PREFIX = "LOCAL-";
 
     @Autowired
     JMadService jMadService;

--- a/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
+++ b/src/java/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnector.java
@@ -1,0 +1,72 @@
+package org.jmad.modelpack.connect.localfile;
+
+import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinition;
+import cern.accsoft.steering.jmad.service.JMadService;
+import org.jmad.modelpack.connect.ConnectorIds;
+import org.jmad.modelpack.connect.InternalModelPackageConnector;
+import org.jmad.modelpack.domain.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+
+import java.io.File;
+
+import static java.util.Arrays.stream;
+
+public class LocalFileModelPackageConnector implements InternalModelPackageConnector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalFileModelPackageConnector.class);
+    private static final Variant LOCAL_VARIANT = Variant.release("LOCAL", new Commit("LOCAL", "LOCAL"));
+    public static final String LOCAL_NAME_PREFIX = "LOCAL-";
+
+    @Autowired
+    JMadService jMadService;
+
+    @Override
+    public Flux<JMadModelDefinition> modelDefinitionsFor(ModelPackageVariant modelPackage) {
+        if (!canHandle(modelPackage.modelPackage().repository())) {
+            return Flux.empty();
+        }
+        String pathToModelPack = modelPackage.modelPackage().repository().baseUrl()
+                + File.separator + modelPackage.modelPackage().id();
+        try {
+            File modelPackDir = new File(pathToModelPack);
+            return Flux.fromIterable(jMadService.getModelDefinitionImporter().importModelDefinitions(modelPackDir));
+        } catch (Exception e) {
+            LOGGER.error("Error loading LOCAL modelpack from '{}'", pathToModelPack, e);
+            return Flux.error(e);
+        }
+    }
+
+    @Override
+    public Flux<ModelPackageVariant> availablePackages(JMadModelPackageRepository repository) {
+        if (!canHandle(repository)) {
+            return Flux.empty();
+        }
+        try {
+            File dir = new File(repository.baseUrl());
+            LOGGER.info("Searching for local models in {}", dir);
+            if (!dir.isDirectory()) {
+                return Flux.error(new IllegalArgumentException(dir.getAbsolutePath() + " is not a directory."));
+            }
+            return Flux.fromStream( //
+                    stream(dir.listFiles(File::isDirectory)) //
+                            .map(File::getName) //
+                            .map(n -> modelPackage(n, repository)));
+        } catch (Exception e) {
+            LOGGER.error("Error loading LOCAL repository '{}'", repository.baseUrl(), e);
+            return Flux.error(e);
+        }
+    }
+
+    private ModelPackageVariant modelPackage(String name, JMadModelPackageRepository repository) {
+        ModelPackage modelPackage = new ModelPackage(LOCAL_NAME_PREFIX +name, repository, name, "Local ModelPack: " + name);
+        return new ModelPackageVariant(modelPackage, LOCAL_VARIANT);
+    }
+
+    @Override
+    public String connectorId() {
+        return ConnectorIds.LOCAL_FILE_CONNECTOR_ID;
+    }
+
+}

--- a/src/java/org/jmad/modelpack/connect/localfile/conf/LocalFileConnectorConfiguration.java
+++ b/src/java/org/jmad/modelpack/connect/localfile/conf/LocalFileConnectorConfiguration.java
@@ -1,0 +1,14 @@
+package org.jmad.modelpack.connect.localfile.conf;
+
+import org.jmad.modelpack.connect.ModelPackageConnector;
+import org.jmad.modelpack.connect.localfile.LocalFileModelPackageConnector;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LocalFileConnectorConfiguration {
+    @Bean
+    public ModelPackageConnector localFileConnector() {
+        return new LocalFileModelPackageConnector();
+    }
+}

--- a/src/java/org/jmad/modelpack/domain/JMadModelRepositories.java
+++ b/src/java/org/jmad/modelpack/domain/JMadModelRepositories.java
@@ -4,24 +4,38 @@
 
 package org.jmad.modelpack.domain;
 
-import static org.jmad.modelpack.connect.ConnectorIds.GITLAB_GROUP_API_V4;
-
 import org.jmad.modelpack.connect.embedded.domain.InternalRepository;
+
+import java.util.Optional;
+
+import static org.jmad.modelpack.connect.ConnectorIds.GITLAB_GROUP_API_V4;
+import static org.jmad.modelpack.connect.ConnectorIds.LOCAL_FILE_CONNECTOR_ID;
 
 public class JMadModelRepositories {
 
     private static final String CERN_GITLAB = "https://gitlab.cern.ch";
+    public static final String PROP_LOCAL_MODEL_REPO = "cern.jmad.modelpacks.local";
 
-    public static final JMadModelPackageRepository cernGitlabTesting() {
+    public static JMadModelPackageRepository cernGitlabTesting() {
         return cernGitlabGroup("jmad-modelpacks-testing");
     }
 
-    public static final JMadModelPackageRepository cernGitlabPro() {
+    public static JMadModelPackageRepository cernGitlabPro() {
         return cernGitlabGroup("jmad-modelpacks-cern");
     }
 
-    public static final InternalRepository internal() {
+    public static InternalRepository internal() {
         return InternalRepository.INTERNAL;
+    }
+
+    public static Optional<JMadModelPackageRepository> defaultLocalFileRepository() {
+        String localModelRepo = System.getProperty(PROP_LOCAL_MODEL_REPO);
+        if (localModelRepo == null) {
+            return Optional.empty();
+        } else {
+
+            return Optional.of(new JMadModelPackageRepository(localModelRepo, "LOCAL", LOCAL_FILE_CONNECTOR_ID));
+        }
     }
 
     private static JMadModelPackageRepository cernGitlabGroup(String groupName) {

--- a/src/java/org/jmad/modelpack/domain/JMadModelRepositories.java
+++ b/src/java/org/jmad/modelpack/domain/JMadModelRepositories.java
@@ -14,7 +14,7 @@ import static org.jmad.modelpack.connect.ConnectorIds.LOCAL_FILE_CONNECTOR_ID;
 public class JMadModelRepositories {
 
     private static final String CERN_GITLAB = "https://gitlab.cern.ch";
-    public static final String PROP_LOCAL_MODEL_REPO = "cern.jmad.modelpacks.local";
+    private static final String PROP_LOCAL_MODEL_REPO = "cern.jmad.modelpacks.local";
 
     public static JMadModelPackageRepository cernGitlabTesting() {
         return cernGitlabGroup("jmad-modelpacks-testing");

--- a/src/java/org/jmad/modelpack/service/conf/JMadModelPackageServiceConfiguration.java
+++ b/src/java/org/jmad/modelpack/service/conf/JMadModelPackageServiceConfiguration.java
@@ -4,30 +4,30 @@
 
 package org.jmad.modelpack.service.conf;
 
-import static org.jmad.modelpack.domain.JMadModelRepositories.cernGitlabPro;
-import static org.jmad.modelpack.domain.JMadModelRepositories.cernGitlabTesting;
-import static org.jmad.modelpack.domain.JMadModelRepositories.internal;
-
+import cern.accsoft.steering.jmad.service.JMadService;
+import cern.accsoft.steering.jmad.util.JMadPreferences;
+import cern.accsoft.steering.jmad.util.TempFileUtilImpl;
 import org.jmad.modelpack.cache.ModelPackageFileCache;
 import org.jmad.modelpack.cache.impl.ModelPackageFileCacheImpl;
 import org.jmad.modelpack.connect.embedded.conf.InternalConnectorConfiguration;
 import org.jmad.modelpack.connect.gitlab.conf.GitlabConnectorConfiguration;
+import org.jmad.modelpack.connect.localfile.conf.LocalFileConnectorConfiguration;
 import org.jmad.modelpack.service.JMadModelPackageService;
 import org.jmad.modelpack.service.impl.ConcurrentModelPackageRepositoryManager;
 import org.jmad.modelpack.service.impl.MultiConnectorModelPackageService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-import cern.accsoft.steering.jmad.service.JMadService;
-import cern.accsoft.steering.jmad.util.JMadPreferences;
-import cern.accsoft.steering.jmad.util.TempFileUtilImpl;
+import static org.jmad.modelpack.domain.JMadModelRepositories.*;
 
 /**
  * Spring configuration that only creates the beans for the jmad-modelpack-service. It expects all the necessary beans
  * already in the context. You can use the {@link JMadModelPackageServiceStandaloneConfiguration} if you want to
  * have a fully configured, ready-to-use, context.
  */
-@Import({ GitlabConnectorConfiguration.class, InternalConnectorConfiguration.class })
+@Import({GitlabConnectorConfiguration.class,
+        InternalConnectorConfiguration.class,
+        LocalFileConnectorConfiguration.class})
 public class JMadModelPackageServiceConfiguration {
 
     @Bean
@@ -44,6 +44,7 @@ public class JMadModelPackageServiceConfiguration {
         ConcurrentModelPackageRepositoryManager manager = new ConcurrentModelPackageRepositoryManager();
         manager.enable(cernGitlabPro());
         manager.enable(internal());
+        defaultLocalFileRepository().ifPresent(manager::enable);
         manager.disable(cernGitlabTesting());
         return manager;
     }

--- a/src/test/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnectorTest.java
+++ b/src/test/org/jmad/modelpack/connect/localfile/LocalFileModelPackageConnectorTest.java
@@ -1,0 +1,105 @@
+package org.jmad.modelpack.connect.localfile;
+
+import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinition;
+import cern.accsoft.steering.jmad.modeldefs.io.JMadModelDefinitionImporter;
+import cern.accsoft.steering.jmad.service.JMadService;
+import org.jmad.modelpack.connect.ConnectorIds;
+import org.jmad.modelpack.domain.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.util.FileSystemUtils;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LocalFileModelPackageConnectorTest {
+
+    @Mock
+    JMadService jMadService;
+
+    @Mock
+    JMadModelDefinitionImporter importer;
+
+    @InjectMocks
+    LocalFileModelPackageConnector connector;
+
+    JMadModelPackageRepository repository;
+    Path tmpRepoDir;
+
+    @Before
+    public void setUp() throws Exception {
+        tmpRepoDir = Files.createTempDirectory("test-modelpack");
+        Files.createDirectory(modelpackFile("modelpack-1").toPath());
+        Files.createDirectory(modelpackFile("test-modelpack").toPath());
+        Files.createDirectory(modelpackFile("another-modelpack").toPath());
+        repository = new JMadModelPackageRepository(tmpRepoDir.toAbsolutePath().toString(), "TEST", ConnectorIds.LOCAL_FILE_CONNECTOR_ID);
+        when(jMadService.getModelDefinitionImporter()).thenReturn(importer);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        FileSystemUtils.deleteRecursively(tmpRepoDir);
+    }
+
+    private File modelpackFile(String name) {
+        String tmpPrefix = tmpRepoDir.toAbsolutePath().toString() + File.separator;
+        return new File(tmpPrefix + name);
+    }
+
+    @Test
+    public void modelDefinitionsFor_unsupportedModelPack_shouldReturnEmpty() {
+        JMadModelPackageRepository unsupportedRepo = new JMadModelPackageRepository("foo",
+                "TEST", ConnectorIds.INTERNAL_CONNECTOR_ID);
+        ModelPackage modelPackage = new ModelPackage("modelpack-1", unsupportedRepo, "modelpack-1", "Test");
+        ModelPackageVariant variant = new ModelPackageVariant(modelPackage, Variant.release("LOCAL", new Commit("LOCAL", "LOCAL")));
+        List<JMadModelDefinition> modelDefinitions = connector.modelDefinitionsFor(variant).collectList().block();
+        verifyZeroInteractions(importer);
+        assertThat(modelDefinitions).isEmpty();
+    }
+
+    @Test
+    public void modelDefinitionsFor_validModelPack_shouldDelegate() {
+        ModelPackage modelPackage = new ModelPackage("modelpack-1", repository, "modelpack-1", "Test");
+        ModelPackageVariant variant = new ModelPackageVariant(modelPackage, Variant.release("LOCAL", new Commit("LOCAL", "LOCAL")));
+        connector.modelDefinitionsFor(variant).blockFirst();
+        verify(importer, times(1)).importModelDefinitions(modelpackFile("modelpack-1"));
+    }
+
+    @Test
+    public void availablePackages_forUnsupportedModelRepo_shouldReturnEmpty() {
+        JMadModelPackageRepository repo = new JMadModelPackageRepository("foo",
+                "TEST", ConnectorIds.INTERNAL_CONNECTOR_ID);
+        List<ModelPackageVariant> allModelPacks = connector.availablePackages(repo).collectList().block();
+        assertThat(allModelPacks).isEmpty();
+    }
+
+    @Test
+    public void availablePackages_forSupportedModelRepoButBadDirectory_shouldReturnError() {
+        JMadModelPackageRepository repo = new JMadModelPackageRepository("/i/do/not/exist",
+                "TEST", ConnectorIds.LOCAL_FILE_CONNECTOR_ID);
+        assertThatExceptionOfType(IllegalArgumentException.class) //
+                .isThrownBy(() -> connector.availablePackages(repo).blockFirst()) //
+                .withMessageContaining("/i/do/not/exist is not a directory");
+    }
+
+    @Test
+    public void availablePackages_forSupportedModelRepo_shouldListModelPacks() {
+        List<ModelPackageVariant> allModelPacks = connector.availablePackages(repository).collectList().block();
+        assertThat(allModelPacks.stream().map(ModelPackageVariant::modelPackage).map(ModelPackage::id))
+                .containsExactlyInAnyOrder("modelpack-1", "test-modelpack", "another-modelpack");
+        assertThat(allModelPacks.stream().map(ModelPackageVariant::modelPackage).map(ModelPackage::name))
+                .containsExactlyInAnyOrder("LOCAL-modelpack-1", "LOCAL-test-modelpack", "LOCAL-another-modelpack");
+    }
+}


### PR DESCRIPTION
This change set adds a model repository connector for the local file system, to be used mainly during model development.

In the default configuration, it is enabled by setting the system property ``cern.jmad.modelpacks.local`` to a path containing one or more model packs.